### PR TITLE
:fire: feat: support field resolver for all ObjectType

### DIFF
--- a/server/entities/Executor.ts
+++ b/server/entities/Executor.ts
@@ -1,5 +1,5 @@
 import { Extensions, Field, Int, ObjectType } from "type-graphql";
-import { TypeormLoader } from "type-graphql-dataloader";
+import { TypeormLoader } from "../lib/dataloader";
 import { plainToClass } from "class-transformer";
 
 import {
@@ -81,7 +81,7 @@ export default class Executor extends BaseEntity implements IExecutor {
     cascade: true,
     nullable: true,
   })
-  // @TypeormLoader((type) => Task, (executor: Executor) => executor.taskIds)
+  @TypeormLoader((type) => Task, (executor: Executor) => executor.taskIds)
   tasks?: Task[];
 
   @RelationId((executor: Executor) => executor.tasks)

--- a/server/entities/Recipt.ts
+++ b/server/entities/Recipt.ts
@@ -1,0 +1,57 @@
+import { Field, ObjectType } from "type-graphql";
+import { plainToClass } from "class-transformer";
+
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  BaseEntity,
+  CreateDateColumn,
+  UpdateDateColumn,
+  OneToOne,
+} from "typeorm";
+
+import { CompanyScale } from "../graphql/Recipe";
+
+@Entity()
+export class Company extends BaseEntity {
+  @PrimaryGeneratedColumn()
+  companyId!: number;
+
+  // @Column()
+  // name!: string;
+
+  // @Column({ default: CompanyScale.Middle })
+  // scale!: CompanyScale;
+
+  // @Column()
+  // description!: string;
+
+  // @CreateDateColumn({ comment: "注册时间" })
+  // registerDate!: Date;
+
+  // @UpdateDateColumn({ comment: "更新时间" })
+  // lastUpdateDate!: Date;
+}
+
+// need to use TypeORM Relations
+// @Entity()
+// export class WorkExperience extends BaseEntity {
+//   @PrimaryGeneratedColumn()
+//   workExpRecordId!: number;
+
+//   @Column()
+//   company!: Company;
+
+//   @Column()
+//   isFired!: boolean;
+
+//   @Column()
+//   workYears!: number;
+
+//   @CreateDateColumn({ comment: "注册时间" })
+//   createDate!: Date;
+
+//   @UpdateDateColumn({ comment: "更新时间" })
+//   lastUpdateDate!: Date;
+// }

--- a/server/graphql/Common.ts
+++ b/server/graphql/Common.ts
@@ -115,14 +115,14 @@ export class PaginationOptions implements IPaginationOptions {
   @Min(0)
   @IsOptional()
   @IsNumber()
-  cursor?: number;
+  offset?: number;
 
   @Field(() => Int, { nullable: true })
   @Max(200)
   @Min(0)
   @IsOptional()
   @IsNumber()
-  offset?: number;
+  take?: number;
 }
 
 export const AccountUnionResult = createUnionType({

--- a/server/graphql/Recipe.ts
+++ b/server/graphql/Recipe.ts
@@ -41,7 +41,7 @@ export class Company {
   @Field()
   name!: string;
 
-  @Field((type) => CompanyScale, { nullable: true })
+  @Field((type) => CompanyScale)
   scale!: CompanyScale;
 
   @Field()

--- a/server/lib/dataloader/decorator.ts
+++ b/server/lib/dataloader/decorator.ts
@@ -1,0 +1,256 @@
+import DataLoader from "dataloader";
+import { UseMiddleware } from "type-graphql";
+import Container from "typedi";
+
+import { RelationMetadata } from "typeorm/metadata/RelationMetadata";
+import { ColumnMetadata } from "typeorm/metadata/ColumnMetadata";
+
+import { keyBy, groupBy, Dictionary } from "lodash";
+
+import type { ObjectType, Connection } from "typeorm";
+import type { IContext, TypeGraphQLDataLoaderContext } from "../../typing";
+
+type KeyFunc = (root: any) => any | any[] | undefined;
+
+type ReturnTypeFunc<T> = (type?: void) => ObjectType<T>;
+
+interface TypeormLoaderOption {
+  selfKey: boolean;
+}
+
+export function TypeormLoader(
+  keyFunc: KeyFunc,
+  option?: TypeormLoaderOption
+): PropertyDecorator;
+
+export function TypeormLoader<V>(
+  typeFunc: ReturnTypeFunc<V>,
+  keyFunc: KeyFunc,
+  option?: TypeormLoaderOption
+): PropertyDecorator;
+
+// TODO: reduce overload
+export function TypeormLoader<V>(
+  typeFuncOrKeyFunc: ReturnTypeFunc<V> | KeyFunc,
+  keyFuncOrOption?: KeyFunc | TypeormLoaderOption,
+  option?: TypeormLoaderOption
+): PropertyDecorator {
+  const getArgs = (): [KeyFunc, TypeormLoaderOption | undefined] => {
+    return option != null || typeof keyFuncOrOption == "function"
+      ? [keyFuncOrOption as KeyFunc, option]
+      : [typeFuncOrKeyFunc as KeyFunc, keyFuncOrOption as TypeormLoaderOption];
+  };
+  return TypeormLoaderImpl<V>(...getArgs());
+}
+
+function TypeormLoaderImpl<V>(
+  keyFunc: KeyFunc,
+  option?: TypeormLoaderOption
+): PropertyDecorator {
+  return (target: Object, propertyKey: string | symbol) => {
+    UseMiddleware(async ({ root, context }, next) => {
+      const tgdContext = (context as IContext).tgdLoader;
+
+      if (tgdContext.connectionGetter == null) {
+        throw Error("[TypeGraphQL DataLoader] typeormGetConnection is not set");
+      }
+
+      const relation = tgdContext
+        .connectionGetter()
+        .getMetadata(target.constructor)
+        .findRelationWithPropertyPath(propertyKey.toString());
+
+      if (relation == null) {
+        return await next();
+      }
+
+      if (
+        option?.selfKey &&
+        !(relation.isOneToMany || relation.isOneToOneNotOwner)
+      ) {
+        throw Error(
+          "[TypeGraphQL DataLoader] selfKey option is available only for OneToMany or OneToOneNotOwner"
+        );
+      }
+
+      const appropriateHandler =
+        relation.isManyToOne || relation.isOneToOneOwner
+          ? handleToOne
+          : relation.isOneToMany
+          ? option?.selfKey
+            ? handleOneToManyWithSelfKey
+            : handleToMany
+          : relation.isOneToOneNotOwner
+          ? option?.selfKey
+            ? handleOneToOneNotOwnerWithSelfKey
+            : handleToOne
+          : relation.isManyToMany
+          ? handleToMany
+          : () => next();
+
+      return await appropriateHandler<V>(keyFunc, root, tgdContext, relation);
+    })(target, propertyKey);
+  };
+}
+
+async function handler<V>(
+  { requestId, connectionGetter }: TypeGraphQLDataLoaderContext,
+  relation: RelationMetadata,
+  columns: ColumnMetadata[],
+  newDataloader: (connection: Connection) => DataLoader<any, V>,
+  callback: (
+    dataloader: DataLoader<any, V>,
+    columns: ColumnMetadata[]
+  ) => Promise<any>
+) {
+  if (connectionGetter == null) {
+    throw Error("Connection is not available");
+  }
+
+  if (columns.length !== 1) {
+    throw Error("Loading by multiple columns as foreign key is not supported.");
+  }
+
+  const serviceId = `tgd-typeorm#${relation.entityMetadata.tableName}#${relation.propertyName}`;
+  const container = Container.of(requestId);
+  if (!container.has(serviceId)) {
+    container.set(serviceId, newDataloader(connectionGetter()));
+  }
+
+  return callback(container.get<DataLoader<any, any>>(serviceId), columns);
+}
+
+async function handleToMany<V>(
+  foreignKeyFunc: (root: any) => any | undefined,
+  root: any,
+  tgdContext: TypeGraphQLDataLoaderContext,
+  relation: RelationMetadata
+) {
+  return handler(
+    tgdContext,
+    relation,
+    relation.inverseEntityMetadata.primaryColumns,
+    (connection) => new ToManyDataloader<V>(relation, connection),
+    async (dataloader) => {
+      const fks = foreignKeyFunc(root);
+      return await dataloader.loadMany(fks);
+    }
+  );
+}
+
+async function handleToOne<V>(
+  foreignKeyFunc: (root: any) => any | undefined,
+  root: any,
+  tgdContext: TypeGraphQLDataLoaderContext,
+  relation: RelationMetadata
+) {
+  return handler(
+    tgdContext,
+    relation,
+    relation.inverseEntityMetadata.primaryColumns,
+    (connection) => new ToOneDataloader<V>(relation, connection),
+    async (dataloader) => {
+      const fk = foreignKeyFunc(root);
+      return fk != null ? await dataloader.load(fk) : null;
+    }
+  );
+}
+
+async function handleOneToManyWithSelfKey<V>(
+  selfKeyFunc: (root: any) => any | any[],
+  root: any,
+  tgdContext: TypeGraphQLDataLoaderContext,
+  relation: RelationMetadata
+) {
+  return handler(
+    tgdContext,
+    relation,
+    relation.entityMetadata.primaryColumns,
+    (connection) => new SelfKeyDataloader<V>(relation, connection, selfKeyFunc),
+    async (dataloader, columns) => {
+      const pk = columns[0].getEntityValue(root);
+      return await dataloader.load(pk);
+    }
+  );
+}
+
+async function handleOneToOneNotOwnerWithSelfKey<V>(
+  selfKeyFunc: (root: any) => any | undefined,
+  root: any,
+  tgdContext: TypeGraphQLDataLoaderContext,
+  relation: RelationMetadata
+) {
+  return handler(
+    tgdContext,
+    relation,
+    relation.entityMetadata.primaryColumns,
+    (connection) => new SelfKeyDataloader<V>(relation, connection, selfKeyFunc),
+    async (dataloader, columns) => {
+      const pk = columns[0].getEntityValue(root);
+      return (await dataloader.load(pk))[0] ?? null;
+    }
+  );
+}
+
+function directLoader<V>(
+  relation: RelationMetadata,
+  connection: Connection,
+  grouper: string | ((entity: V) => any)
+) {
+  return async (ids: readonly any[]) => {
+    const entities = keyBy(
+      await connection
+        .createQueryBuilder<V>(relation.type, relation.propertyName)
+        .whereInIds(ids)
+        .getMany(),
+      grouper
+    ) as Dictionary<V>;
+    return ids.map((id) => entities[id]);
+  };
+}
+
+class ToManyDataloader<V> extends DataLoader<any, V> {
+  constructor(relation: RelationMetadata, connection: Connection) {
+    super(
+      directLoader(relation, connection, (entity) =>
+        relation.inverseEntityMetadata.primaryColumns[0].getEntityValue(entity)
+      )
+    );
+  }
+}
+
+class ToOneDataloader<V> extends DataLoader<any, V> {
+  constructor(relation: RelationMetadata, connection: Connection) {
+    super(
+      directLoader(
+        relation,
+        connection,
+        relation.inverseEntityMetadata.primaryColumns[0].propertyName
+      )
+    );
+  }
+}
+
+class SelfKeyDataloader<V> extends DataLoader<any, V[]> {
+  constructor(
+    relation: RelationMetadata,
+    connection: Connection,
+    selfKeyFunc: (root: any) => any
+  ) {
+    super(async (ids) => {
+      const columns = relation.inverseRelation!.joinColumns;
+      const k = `${relation.propertyName}_${columns[0].propertyName}`;
+      const entities = groupBy(
+        await connection
+          .createQueryBuilder<V>(relation.type, relation.propertyName)
+          .where(
+            `${relation.propertyName}.${columns[0].propertyPath} IN (:...${k})`
+          )
+          .setParameter(k, ids)
+          .getMany(),
+        selfKeyFunc
+      );
+      return ids.map((id) => entities[id] ?? []);
+    });
+  }
+}

--- a/server/lib/dataloader/index.ts
+++ b/server/lib/dataloader/index.ts
@@ -1,0 +1,4 @@
+// origin repo: https://github.com/slaypni/type-graphql-dataloader
+export * from "./plugin";
+export * from "./decorator";
+export * from "./loader";

--- a/server/lib/dataloader/loader.ts
+++ b/server/lib/dataloader/loader.ts
@@ -1,0 +1,44 @@
+import { UseMiddleware } from "type-graphql";
+import { MethodAndPropDecorator } from "type-graphql/dist/decorators/types";
+import DataLoader from "dataloader";
+import Container from "typedi";
+import type { IContext, TypeGraphQLDataLoaderContext } from "../../typing";
+
+interface ResolverData {
+  context: any;
+}
+
+type BatchLoadFn<K, V> = (
+  keys: ReadonlyArray<K>,
+  data: ResolverData
+) => PromiseLike<ArrayLike<V | Error>>;
+
+export function Loader<K, V, C = K>(
+  batchLoadFn: BatchLoadFn<K, V>,
+  options?: DataLoader.Options<K, V, C>
+): MethodAndPropDecorator {
+  return (
+    target: Object,
+    propertyKey: string | symbol,
+    descriptor?: TypedPropertyDescriptor<any>
+  ) => {
+    UseMiddleware(async ({ context }, next) => {
+      const serviceId = `TypeGraphQL-DataLoader#${
+        target.constructor.name
+      }#${propertyKey.toString()}`;
+
+      const { requestId } = (context as IContext).tgdLoader;
+
+      const container = Container.of(requestId);
+
+      if (!container.has(serviceId)) {
+        container.set(
+          serviceId,
+          new DataLoader((keys) => batchLoadFn(keys, { context }), options)
+        );
+      }
+      const dataloader = container.get(serviceId);
+      return await (await next())(dataloader);
+    })(target, propertyKey);
+  };
+}

--- a/server/lib/dataloader/plugin.ts
+++ b/server/lib/dataloader/plugin.ts
@@ -1,0 +1,28 @@
+import { Container } from "typedi";
+import type { Connection } from "typeorm";
+import { v4 as uuidv4 } from "uuid";
+
+import { IContext, TypeGraphQLDataLoaderContext } from "../../typing";
+
+interface ApolloServerLoaderPluginOption {
+  connectionGetter?: () => Connection;
+}
+
+export const ApolloServerLoaderPlugin = (
+  option?: ApolloServerLoaderPluginOption
+) => ({
+  // TODO: support more life cycle
+  requestDidStart: () => ({
+    didResolveSource(requestContext: { context }) {
+      requestContext.context.tgdLoader = {
+        // use accountId ?
+        requestId: uuidv4(),
+        connectionGetter: option?.connectionGetter,
+      };
+    },
+
+    willSendResponse(requestContext: { context }) {
+      Container.reset(requestContext.context.tgdLoader.requestId);
+    },
+  }),
+});

--- a/server/middlewares/dataLoader.ts
+++ b/server/middlewares/dataLoader.ts
@@ -47,14 +47,15 @@ export default class DataLoaderMiddleware
         ),
       };
 
-      // FIXME: use a better name
       loaders.sysLoader = {
+        // Support Only OneToOne Relations
         // FIXME: ManyToOne / ManyToMnay Relations Handle
         // executorLoader: new DataLoader((recordIds: Readonly<number[]>) =>
         //   executorService.getFullExecutorByRecordIdsBatch(recordIds)
         // ),
       };
 
+      //
       context.connection.entityMetadatas.forEach((entityMetadata) => {
         const resolver = entityMetadata.targetName;
         if (!resolver) return;

--- a/server/resolvers/fields/Account.resolver.ts
+++ b/server/resolvers/fields/Account.resolver.ts
@@ -1,20 +1,24 @@
-import { Resolver, Root, FieldResolver } from "type-graphql";
+import { Resolver, Root, FieldResolver, Arg } from "type-graphql";
 
 import Account from "../../entities/Account";
+import Record from "../../entities/Record";
 
 import AccountService from "../../services/Account.service";
+import RecordService from "../../services/Record.service";
 
 @Resolver((of) => Account)
 export default class AccountFieldResolver {
-  constructor(private readonly accountService: AccountService) {}
+  constructor(
+    private readonly accountService: AccountService,
+    private readonly recordService: RecordService
+  ) {}
 
-  // Another Resolver Composite
-  @FieldResolver(() => [Account])
-  async AccountFieldResolver(@Root() account: Account) {
-    const res = await this.accountService.getAllAccounts({
-      offset: 0,
-      take: 200,
-    });
+  @FieldResolver(() => [Record])
+  async RecordFieldResolver(@Root() account: Account) {
+    const res = await this.recordService.getFullRecordByAccountName(
+      account.accountName
+    );
+
     return res;
   }
 }

--- a/server/resolvers/fields/Account.resolver.ts
+++ b/server/resolvers/fields/Account.resolver.ts
@@ -1,0 +1,20 @@
+import { Resolver, Root, FieldResolver } from "type-graphql";
+
+import Account from "../../entities/Account";
+
+import AccountService from "../../services/Account.service";
+
+@Resolver((of) => Account)
+export default class AccountFieldResolver {
+  constructor(private readonly accountService: AccountService) {}
+
+  // Another Resolver Composite
+  @FieldResolver(() => [Account])
+  async AccountFieldResolver(@Root() account: Account) {
+    const res = await this.accountService.getAllAccounts({
+      offset: 0,
+      take: 200,
+    });
+    return res;
+  }
+}

--- a/server/resolvers/fields/Executor.resolver.ts
+++ b/server/resolvers/fields/Executor.resolver.ts
@@ -1,0 +1,23 @@
+import { Resolver, FieldResolver, Root } from "type-graphql";
+
+import Executor from "../../entities/Executor";
+import ExecutorService from "../../services/Executor.service";
+
+@Resolver((of) => Executor)
+export default class ExecutorFieldResolver {
+  constructor(private readonly executorService: ExecutorService) {}
+
+  // Another Resolver Composite
+  @FieldResolver(() => [Executor])
+  async ExecutorFieldResolver(
+    @Root() executor: Executor
+    // TODO: get by conditions
+    // @Arg("executorQueryArgs", { nullable: true}) executorQueryArgs: ExecutorQueryArgs
+  ) {
+    const res = await this.executorService.getAllExecutors({
+      offset: 0,
+      take: 200,
+    });
+    return res;
+  }
+}

--- a/server/resolvers/fields/Executor.resolver.ts
+++ b/server/resolvers/fields/Executor.resolver.ts
@@ -1,23 +1,17 @@
-import { Resolver, FieldResolver, Root } from "type-graphql";
+import { Resolver, FieldResolver, Root, Ctx } from "type-graphql";
 
 import Executor from "../../entities/Executor";
-import ExecutorService from "../../services/Executor.service";
+import Task from "../../entities/Task";
+
+import { IContext } from "../../typing";
 
 @Resolver((of) => Executor)
 export default class ExecutorFieldResolver {
-  constructor(private readonly executorService: ExecutorService) {}
-
-  // Another Resolver Composite
-  @FieldResolver(() => [Executor])
-  async ExecutorFieldResolver(
-    @Root() executor: Executor
-    // TODO: get by conditions
-    // @Arg("executorQueryArgs", { nullable: true}) executorQueryArgs: ExecutorQueryArgs
+  @FieldResolver(() => [Task])
+  async ExecutorInnerTaskFieldResolver(
+    @Root() executor: Executor,
+    @Ctx() ctx: IContext
   ) {
-    const res = await this.executorService.getAllExecutors({
-      offset: 0,
-      take: 200,
-    });
-    return res;
+    return await ctx.dataLoader.loaders.Executor.tasks.load(executor);
   }
 }

--- a/server/resolvers/fields/Executor.resolver.ts
+++ b/server/resolvers/fields/Executor.resolver.ts
@@ -1,4 +1,5 @@
 import { Resolver, FieldResolver, Root, Ctx } from "type-graphql";
+import { getRepository } from "typeorm";
 
 import Executor from "../../entities/Executor";
 import Task from "../../entities/Task";

--- a/server/resolvers/fields/Record.resolver.ts
+++ b/server/resolvers/fields/Record.resolver.ts
@@ -1,5 +1,6 @@
 import { GraphQLResolveInfo } from "graphql";
 import { Resolver, FieldResolver, Root, Info, Ctx } from "type-graphql";
+import { getRepository } from "typeorm";
 
 import Account from "../../entities/Account";
 import Record from "../../entities/Record";

--- a/server/resolvers/fields/Record.resolver.ts
+++ b/server/resolvers/fields/Record.resolver.ts
@@ -1,17 +1,54 @@
-import { Resolver, FieldResolver, Root } from "type-graphql";
+import { GraphQLResolveInfo } from "graphql";
+import { Resolver, FieldResolver, Root, Info } from "type-graphql";
 
+import Account from "../../entities/Account";
 import Record from "../../entities/Record";
+import Executor from "../../entities/Executor";
+import Substance from "../../entities/Substance";
+import Task from "../../entities/Task";
 
+import AccountService from "../../services/Account.service";
 import RecordService from "../../services/Record.service";
+import ExecutorService from "../../services/Executor.service";
+import SubstanceService from "../../services/Substance.service";
+import TaskService from "../../services/Task.service";
 
 @Resolver((of) => Record)
 export default class RecordFieldResolver {
-  constructor(private readonly recordService: RecordService) {}
+  constructor(
+    private readonly accountService: AccountService,
+    private readonly recordService: RecordService,
+    private readonly executorService: ExecutorService,
+    private readonly substancesService: SubstanceService,
+    private readonly taskService: TaskService
+  ) {}
 
-  // Another Resolver Composite
-  @FieldResolver(() => [Record])
-  async RecordFieldResolver(@Root() record: Record) {
-    const res = await this.recordService.getAllRecords();
-    return res;
+  // should support this ?
+  // @FieldResolver(() => [Account])
+  // async AccountFieldResolver(
+  //   @Root() record: Record,
+  //   @Info() info: GraphQLResolveInfo
+  // ) {
+  //   const res = await this.accountService.getFullAccountByRecordId(record.recordId)
+  //   return res;
+  // }
+
+  @FieldResolver(() => [Executor])
+  async ExecutorFieldResolver(@Root() record: Record) {
+    return await this.executorService.getFullExecutorByRecordId(
+      record.recordId
+    );
+  }
+
+  @FieldResolver(() => [Substance])
+  async SubstanceFieldResolver(@Root() record: Record) {
+    return await this.substancesService.getFullSubstanceByRecordId(
+      record.recordId
+    );
+  }
+
+  @FieldResolver(() => [Task])
+  async TaskFieldResolver(@Root() record: Record) {
+    return await this.taskService.getFullTaskByRecordId(record.recordId);
   }
 }

--- a/server/resolvers/fields/Record.resolver.ts
+++ b/server/resolvers/fields/Record.resolver.ts
@@ -1,5 +1,5 @@
 import { GraphQLResolveInfo } from "graphql";
-import { Resolver, FieldResolver, Root, Info } from "type-graphql";
+import { Resolver, FieldResolver, Root, Info, Ctx } from "type-graphql";
 
 import Account from "../../entities/Account";
 import Record from "../../entities/Record";
@@ -12,6 +12,7 @@ import RecordService from "../../services/Record.service";
 import ExecutorService from "../../services/Executor.service";
 import SubstanceService from "../../services/Substance.service";
 import TaskService from "../../services/Task.service";
+import { IContext } from "../../typing";
 
 @Resolver((of) => Record)
 export default class RecordFieldResolver {
@@ -34,21 +35,21 @@ export default class RecordFieldResolver {
   // }
 
   @FieldResolver(() => [Executor])
-  async ExecutorFieldResolver(@Root() record: Record) {
-    return await this.executorService.getFullExecutorByRecordId(
-      record.recordId
-    );
+  async ExecutorFieldResolver(@Root() record: Record, @Ctx() ctx: IContext) {
+    return [await ctx.dataLoader.loaders.Record.recordExecutor.load(record)];
   }
 
   @FieldResolver(() => [Substance])
-  async SubstanceFieldResolver(@Root() record: Record) {
-    return await this.substancesService.getFullSubstanceByRecordId(
-      record.recordId
-    );
+  async SubstanceFieldResolver(@Root() record: Record, @Ctx() ctx: IContext) {
+    // return await this.substancesService.getFullSubstanceByRecordId(
+    //   record.recordId
+    // );
+    return [await ctx.dataLoader.loaders.Record.recordSubstance.load(record)];
   }
 
   @FieldResolver(() => [Task])
-  async TaskFieldResolver(@Root() record: Record) {
-    return await this.taskService.getFullTaskByRecordId(record.recordId);
+  async TaskFieldResolver(@Root() record: Record, @Ctx() ctx: IContext) {
+    // return await this.taskService.getFullTaskByRecordId(record.recordId);
+    return [await ctx.dataLoader.loaders.Record.recordTask.load(record)];
   }
 }

--- a/server/resolvers/fields/Record.resolver.ts
+++ b/server/resolvers/fields/Record.resolver.ts
@@ -1,0 +1,17 @@
+import { Resolver, FieldResolver, Root } from "type-graphql";
+
+import Record from "../../entities/Record";
+
+import RecordService from "../../services/Record.service";
+
+@Resolver((of) => Record)
+export default class RecordFieldResolver {
+  constructor(private readonly recordService: RecordService) {}
+
+  // Another Resolver Composite
+  @FieldResolver(() => [Record])
+  async RecordFieldResolver(@Root() record: Record) {
+    const res = await this.recordService.getAllRecords();
+    return res;
+  }
+}

--- a/server/resolvers/fields/Record.resolver.ts
+++ b/server/resolvers/fields/Record.resolver.ts
@@ -24,23 +24,19 @@ export default class RecordFieldResolver {
     private readonly taskService: TaskService
   ) {}
 
-  // should support this ?
-  // @FieldResolver(() => [Account])
-  // async AccountFieldResolver(
-  //   @Root() record: Record,
-  //   @Info() info: GraphQLResolveInfo
-  // ) {
-  //   const res = await this.accountService.getFullAccountByRecordId(record.recordId)
-  //   return res;
-  // }
-
   @FieldResolver(() => [Executor])
-  async ExecutorFieldResolver(@Root() record: Record, @Ctx() ctx: IContext) {
+  async RecordInnerExecutorFieldResolver(
+    @Root() record: Record,
+    @Ctx() ctx: IContext
+  ) {
     return [await ctx.dataLoader.loaders.Record.recordExecutor.load(record)];
   }
 
   @FieldResolver(() => [Substance])
-  async SubstanceFieldResolver(@Root() record: Record, @Ctx() ctx: IContext) {
+  async RecordInnerSubstanceFieldResolver(
+    @Root() record: Record,
+    @Ctx() ctx: IContext
+  ) {
     // return await this.substancesService.getFullSubstanceByRecordId(
     //   record.recordId
     // );
@@ -48,7 +44,10 @@ export default class RecordFieldResolver {
   }
 
   @FieldResolver(() => [Task])
-  async TaskFieldResolver(@Root() record: Record, @Ctx() ctx: IContext) {
+  async RecordInnerTaskFieldResolver(
+    @Root() record: Record,
+    @Ctx() ctx: IContext
+  ) {
     // return await this.taskService.getFullTaskByRecordId(record.recordId);
     return [await ctx.dataLoader.loaders.Record.recordTask.load(record)];
   }

--- a/server/resolvers/fields/Substance.resolver.ts
+++ b/server/resolvers/fields/Substance.resolver.ts
@@ -1,0 +1,35 @@
+import {
+  Resolver,
+  Query,
+  Arg,
+  Mutation,
+  Int,
+  FieldResolver,
+  Root,
+} from "type-graphql";
+
+import Substance from "../../entities/Substance";
+
+import SubstanceService from "../../services/Substance.service";
+import TaskService from "../../services/Task.service";
+
+@Resolver((of) => Substance)
+export default class SubstanceFieldResolver {
+  constructor(
+    private readonly substancesService: SubstanceService,
+    private readonly taskService: TaskService
+  ) {}
+
+  @FieldResolver(() => [])
+  async SubstanceFieldResolver(
+    @Root() substance: Substance
+    // TODO: get by conditions
+    // @Arg("executorQueryArgs", { nullable: true}) executorQueryArgs: ExecutorQueryArgs
+  ) {
+    const res = await this.substancesService.getAllSubstances({
+      offset: 0,
+      take: 200,
+    });
+    return res;
+  }
+}

--- a/server/resolvers/fields/Substance.resolver.ts
+++ b/server/resolvers/fields/Substance.resolver.ts
@@ -1,35 +1,17 @@
-import {
-  Resolver,
-  Query,
-  Arg,
-  Mutation,
-  Int,
-  FieldResolver,
-  Root,
-} from "type-graphql";
+import { Resolver, FieldResolver, Root, Ctx } from "type-graphql";
 
+import Task from "../../entities/Task";
 import Substance from "../../entities/Substance";
 
-import SubstanceService from "../../services/Substance.service";
-import TaskService from "../../services/Task.service";
+import { IContext } from "../../typing";
 
 @Resolver((of) => Substance)
 export default class SubstanceFieldResolver {
-  constructor(
-    private readonly substancesService: SubstanceService,
-    private readonly taskService: TaskService
-  ) {}
-
-  @FieldResolver(() => [])
-  async SubstanceFieldResolver(
-    @Root() substance: Substance
-    // TODO: get by conditions
-    // @Arg("executorQueryArgs", { nullable: true}) executorQueryArgs: ExecutorQueryArgs
+  @FieldResolver(() => Task)
+  async SubstanceInnerTaskFieldResolver(
+    @Root() substance: Substance,
+    @Ctx() ctx: IContext
   ) {
-    const res = await this.substancesService.getAllSubstances({
-      offset: 0,
-      take: 200,
-    });
-    return res;
+    return await ctx.dataLoader.loaders.Substance.relatedTask.load(substance);
   }
 }

--- a/server/resolvers/fields/Task.resolver.ts
+++ b/server/resolvers/fields/Task.resolver.ts
@@ -1,0 +1,33 @@
+import {
+  Resolver,
+  Query,
+  Arg,
+  Mutation,
+  FieldResolver,
+  Root,
+} from "type-graphql";
+
+import Task from "../../entities/Task";
+
+import TaskService from "../../services/Task.service";
+import ExecutorService from "../../services/Executor.service";
+import SubstanceService from "../../services/Substance.service";
+
+@Resolver((of) => Task)
+export default class TaskFieldResolver {
+  constructor(
+    private readonly taskService: TaskService,
+    private readonly executorService: ExecutorService,
+    private readonly SubstanceService: SubstanceService
+  ) {}
+
+  // Another Resolver Composite
+  @FieldResolver(() => [Task])
+  async TaskFieldResolver(@Root() task: Task) {
+    const res = await this.taskService.getAllTasks({
+      offset: 0,
+      take: 200,
+    });
+    return res;
+  }
+}

--- a/server/resolvers/fields/Task.resolver.ts
+++ b/server/resolvers/fields/Task.resolver.ts
@@ -1,33 +1,26 @@
-import {
-  Resolver,
-  Query,
-  Arg,
-  Mutation,
-  FieldResolver,
-  Root,
-} from "type-graphql";
+import { Resolver, FieldResolver, Root, Ctx } from "type-graphql";
 
 import Task from "../../entities/Task";
+import Executor from "../../entities/Executor";
+import Substance from "../../entities/Substance";
 
-import TaskService from "../../services/Task.service";
-import ExecutorService from "../../services/Executor.service";
-import SubstanceService from "../../services/Substance.service";
+import { IContext } from "../../typing";
 
 @Resolver((of) => Task)
 export default class TaskFieldResolver {
-  constructor(
-    private readonly taskService: TaskService,
-    private readonly executorService: ExecutorService,
-    private readonly SubstanceService: SubstanceService
-  ) {}
+  @FieldResolver(() => Substance)
+  async TaskInnerSubstanceFieldResolver(
+    @Root() task: Task,
+    @Ctx() ctx: IContext
+  ) {
+    return await ctx.dataLoader.loaders.Task.taskSubstance.load(task);
+  }
 
-  // Another Resolver Composite
-  @FieldResolver(() => [Task])
-  async TaskFieldResolver(@Root() task: Task) {
-    const res = await this.taskService.getAllTasks({
-      offset: 0,
-      take: 200,
-    });
-    return res;
+  @FieldResolver(() => Executor)
+  async TaskInnerExecutorFieldResolver(
+    @Root() task: Task,
+    @Ctx() ctx: IContext
+  ) {
+    return await ctx.dataLoader.loaders.Task.assignee.load(task);
   }
 }

--- a/server/resolvers/fields/recipes/Cook.resolver.ts
+++ b/server/resolvers/fields/recipes/Cook.resolver.ts
@@ -1,10 +1,10 @@
 import { Service } from "typedi";
 import { Resolver, Arg, FieldResolver, Root, Ctx } from "type-graphql";
 
-import { Cook, WorkExperience } from "../../graphql/Recipe";
-import RecipeService from "../../services/Recipe.service";
-import { log } from "../../utils/helper";
-import { IContext } from "../../typing";
+import { Cook, WorkExperience } from "../../../graphql/Recipe";
+import RecipeService from "../../../services/Recipe.service";
+import { log } from "../../../utils/helper";
+import { IContext } from "../../../typing";
 
 @Service()
 @Resolver((type) => Cook)

--- a/server/resolvers/fields/recipes/Recipe.resolver.ts
+++ b/server/resolvers/fields/recipes/Recipe.resolver.ts
@@ -18,16 +18,16 @@ import {
   Recipe,
   SaltFish,
   Cook,
-} from "../../graphql/Recipe";
+} from "../../../graphql/Recipe";
 
-import RecipeService from "../../services/Recipe.service";
+import RecipeService from "../../../services/Recipe.service";
 
-import CacheMiddleware from "../../middlewares/cache";
+import CacheMiddleware from "../../../middlewares/cache";
 
-import { log } from "../../utils/helper";
+import { log } from "../../../utils/helper";
 
-import { ACCOUNT_TYPE, ACCOUNT_ROLE, AuthRule } from "../../utils/constants";
-import { IContext } from "../../typing";
+import { ACCOUNT_TYPE, ACCOUNT_ROLE, AuthRule } from "../../../utils/constants";
+import { IContext } from "../../../typing";
 
 @Service()
 @Resolver((type) => Recipe)

--- a/server/resolvers/fields/recipes/WorkExp.resolver.ts
+++ b/server/resolvers/fields/recipes/WorkExp.resolver.ts
@@ -1,10 +1,10 @@
 import { Service } from "typedi";
 import { Resolver, Arg, FieldResolver, Root, Ctx } from "type-graphql";
 
-import { WorkExperience, Company } from "../../graphql/Recipe";
-import RecipeService from "../../services/Recipe.service";
-import { log } from "../../utils/helper";
-import { IContext } from "../../typing";
+import { WorkExperience, Company } from "../../../graphql/Recipe";
+import RecipeService from "../../../services/Recipe.service";
+import { log } from "../../../utils/helper";
+import { IContext } from "../../../typing";
 
 @Service()
 @Resolver((type) => WorkExperience)

--- a/server/server.ts
+++ b/server/server.ts
@@ -155,7 +155,6 @@ export default async (): Promise<ApolloServer> => {
       : [...basicMiddlewares, ErrorLoggerMiddleware],
   });
 
-  // 试试在ApolloServer中直接映射的效果
   SchemaDirectiveVisitor.visitSchemaDirectives(schema, {
     sampleDeprecated: DeprecatedDirective,
     fetch: FetchDirective,
@@ -177,6 +176,8 @@ export default async (): Promise<ApolloServer> => {
     greater: GreaterThanDirective,
     less: LessThanDirective,
   });
+
+  await dbConnect();
 
   const server = new ApolloServer({
     schema,
@@ -221,6 +222,7 @@ export default async (): Promise<ApolloServer> => {
           initialized: false,
           loaders: {},
         },
+        connection: getConnection(),
       };
 
       container.set("context", context);
@@ -280,8 +282,6 @@ export default async (): Promise<ApolloServer> => {
       defaultMaxAge: 60,
     },
   });
-
-  await dbConnect();
 
   await insertInitMockData();
 

--- a/server/server.ts
+++ b/server/server.ts
@@ -20,9 +20,15 @@ import SubstanceResolver from "./resolvers/Substance.resolver";
 import PublicResolver from "./resolvers/Public.resolver";
 import RecordResolver from "./resolvers/Record.resolver";
 
-import RecipeResolver from "./resolvers/recipes/Recipe.resolver";
-import CookResolver from "./resolvers/recipes/Cook.resolver";
-import WorkExpResolver from "./resolvers/recipes/WorkExp.resolver";
+import RecipeFieldResolver from "./resolvers/fields/recipes/Recipe.resolver";
+import CookFieldResolver from "./resolvers/fields/recipes/Cook.resolver";
+import WorkExpFieldResolver from "./resolvers/fields/recipes/WorkExp.resolver";
+
+import AccountFieldResolver from "./resolvers/fields/Account.resolver";
+import ExecutorFieldResolver from "./resolvers/fields/Executor.resolver";
+import TaskFieldResolver from "./resolvers/fields/Task.resolver";
+import RecordFieldResolver from "./resolvers/fields/Record.resolver";
+import SubstanceFieldResolver from "./resolvers/fields/Substance.resolver";
 
 // Middlewares & Interceptors Related
 import ResolveTime from "./middlewares/time";
@@ -115,16 +121,24 @@ export default async (): Promise<ApolloServer> => {
   const schema = buildSchemaSync({
     resolvers: [
       ExecutorResolver,
-      RecipeResolver,
       TaskResolver,
-      PubSubResolver,
       AccountResolver,
       SubstanceResolver,
       PublicResolver,
       RecordResolver,
+      // Subscription Resolver
+      PubSubResolver,
+      // Prisma Resolver
       PrismaResolver,
-      CookResolver,
-      WorkExpResolver,
+      // Field Resolver
+      ExecutorFieldResolver,
+      AccountFieldResolver,
+      TaskFieldResolver,
+      SubstanceResolver,
+      RecordFieldResolver,
+      RecipeFieldResolver,
+      CookFieldResolver,
+      WorkExpFieldResolver,
     ],
     // container: Container,
     // scoped-container，每次从context中拿到本次注册容器

--- a/server/server.ts
+++ b/server/server.ts
@@ -52,7 +52,7 @@ import {
   GraphQLResponse,
 } from "apollo-server-plugin-base";
 import ResponseCachePlugin from "apollo-server-plugin-response-cache";
-import { ApolloServerLoaderPlugin } from "type-graphql-dataloader";
+import { ApolloServerLoaderPlugin } from "./lib/dataloader";
 import ComplexityPlugin from "./plugins/complexity";
 import ExtensionPlugin from "./plugins/extension";
 import { SchemaReportPlugin, SchemaUsagePlugin } from "./plugins/report";
@@ -241,7 +241,7 @@ export default async (): Promise<ApolloServer> => {
       ExtensionPlugin(),
       ScopedContainerPlugin(Container),
       ApolloServerLoaderPlugin({
-        typeormGetConnection: getConnection,
+        connectionGetter: getConnection,
       }),
       ResponseCachePlugin({
         // 被标记为PRIVATE的字段缓存只会用于相同sessionID

--- a/server/services/Account.service.ts
+++ b/server/services/Account.service.ts
@@ -74,11 +74,11 @@ export default class AccountService implements IAccountService {
 
     relations: AccountRelation[] = []
   ): Promise<Account[]> {
-    const { cursor, offset } = pagination;
+    const { offset, take } = pagination;
 
     const accounts = await this.generateSelectBuilder(relations)
-      .take(offset)
-      .skip(cursor)
+      .skip(offset)
+      .take(take)
       .cache(TypeORMCacheIds.account, 1000 * 5)
       .getMany();
 

--- a/server/services/Executor.service.ts
+++ b/server/services/Executor.service.ts
@@ -190,4 +190,17 @@ export default class ExecutorService implements IExecutorService {
 
     await this.connection.queryResultCache?.remove([TypeORMCacheIds.executor]);
   }
+
+  async getFullExecutorByRecordId(recordId: number): Promise<Executor[]> {
+    console.log("getFullExecutorByRecordId Invoked: " + recordId);
+    const res = await this.generateSelectBuilder([
+      "relatedRecord",
+      "substance",
+      "tasks",
+    ])
+      .where("records.recordId = :recordId", { recordId })
+      .getMany();
+
+    return res;
+  }
 }

--- a/server/services/Executor.service.ts
+++ b/server/services/Executor.service.ts
@@ -203,4 +203,21 @@ export default class ExecutorService implements IExecutorService {
 
     return res;
   }
+
+  async getFullExecutorByRecordIdsBatch(
+    recordIds: Readonly<number[]>
+  ): Promise<Executor[]> {
+    console.log("getFullExecutorByRecordIdsBatch Invoked: " + recordIds);
+    const res = await this.generateSelectBuilder([
+      "relatedRecord",
+      "substance",
+      "tasks",
+    ])
+      .where("records.recordId IN (:...recordIds)", { recordIds })
+      .getMany();
+
+    console.log(res);
+
+    return res;
+  }
 }

--- a/server/services/Executor.service.ts
+++ b/server/services/Executor.service.ts
@@ -110,10 +110,10 @@ export default class ExecutorService implements IExecutorService {
 
     relations: ExecutorRelation[] = []
   ) {
-    const { cursor, offset } = pagination;
+    const { offset, take } = pagination;
     const res = await this.generateSelectBuilder(relations)
-      .take(offset)
-      .skip(cursor)
+      .skip(offset)
+      .take(take)
       .cache(TypeORMCacheIds.executor, 1000 * 5)
       .getMany();
 

--- a/server/services/Record.service.ts
+++ b/server/services/Record.service.ts
@@ -30,4 +30,19 @@ export default class RecordService implements IRecordService {
     });
     return records;
   }
+
+  async getFullRecordByAccountName(accountName: string): Promise<Record[]> {
+    const selectQueryBuilder = this.recordRepository
+      .createQueryBuilder("record")
+      .leftJoinAndSelect("record.recordAccount", "account")
+      .leftJoinAndSelect("record.recordExecutor", "executor")
+      .leftJoinAndSelect("record.recordSubstance", "substance")
+      .leftJoinAndSelect("record.recordTask", "task");
+
+    const records = await selectQueryBuilder
+      .where("account.accountName = :accountName", { accountName })
+      .getMany();
+
+    return records;
+  }
 }

--- a/server/services/Substance.service.ts
+++ b/server/services/Substance.service.ts
@@ -188,4 +188,16 @@ export default class SubstanceService implements ISubstanceService {
 
     await this.connection.queryResultCache?.remove([TypeORMCacheIds.substance]);
   }
+
+  async getFullSubstanceByRecordId(recordId: number): Promise<Substance[]> {
+    const res = await this.generateSelectBuilder([
+      "relatedRecord",
+      "assignee",
+      "relatedTask",
+    ])
+      .where("records.recordId = :recordId", { recordId })
+      .getMany();
+
+    return res;
+  }
 }

--- a/server/services/Substance.service.ts
+++ b/server/services/Substance.service.ts
@@ -68,6 +68,7 @@ export default class SubstanceService implements ISubstanceService {
         .leftJoinAndSelect("records.recordTask", "recordTask")
         .leftJoinAndSelect("records.recordAccount", "recordAccount");
     }
+
     if (relations.includes("relatedTask")) {
       selectQueryBuilder = selectQueryBuilder.leftJoinAndSelect(
         "substance.relatedTask",
@@ -106,13 +107,13 @@ export default class SubstanceService implements ISubstanceService {
 
   async getAllSubstances(
     pagination: Required<PaginationOptions>,
-    relations: SubstanceRelation[]
+    relations: SubstanceRelation[] = []
   ): Promise<Substance[]> {
-    const { cursor, offset } = pagination;
+    const { offset, take } = pagination;
 
     const res = await this.generateSelectBuilder(relations)
-      .take(offset)
-      .skip(cursor)
+      .skip(offset)
+      .take(take)
       .cache(TypeORMCacheIds.substance, 1000 * 5)
       .getMany();
 
@@ -147,11 +148,11 @@ export default class SubstanceService implements ISubstanceService {
     pagination: Required<PaginationOptions>,
     relations: SubstanceRelation[] = []
   ): Promise<Substance[]> {
-    const { cursor, offset } = pagination;
+    const { offset, take } = pagination;
 
     const res = await this.SubstanceConditionQuery(conditions, relations)
-      .take(offset)
-      .skip(cursor)
+      .skip(offset)
+      .take(take)
       .getMany();
 
     return res;

--- a/server/services/Task.service.ts
+++ b/server/services/Task.service.ts
@@ -181,4 +181,16 @@ export default class TaskService implements ITaskService {
       TypeORMCacheIds.substance,
     ]);
   }
+
+  async getFullTaskByRecordId(recordId: number): Promise<Task[]> {
+    const res = await this.generateSelectBuilder([
+      "relatedRecord",
+      "assignee",
+      "taskSubstance",
+    ])
+      .where("records.recordId = :recordId", { recordId })
+      .getMany();
+
+    return res;
+  }
 }

--- a/server/services/Task.service.ts
+++ b/server/services/Task.service.ts
@@ -107,11 +107,11 @@ export default class TaskService implements ITaskService {
     pagination: Required<PaginationOptions>,
     relations: TaskRelation[] = []
   ): Promise<Task[]> {
-    const { cursor, offset } = pagination;
+    const { offset, take } = pagination;
 
     const res = await this.generateSelectBuilder(relations)
-      .take(offset)
-      .skip(cursor)
+      .skip(offset)
+      .take(take)
       .cache(TypeORMCacheIds.task, 1000 * 5)
       .getMany();
 

--- a/server/typegraphql/schema.graphql
+++ b/server/typegraphql/schema.graphql
@@ -4,8 +4,6 @@
 # -----------------------------------------------
 
 type Account implements IAccount {
-  AccountFieldResolver: [Account!]!
-
   """
   ACCOUNT_JSON_TYPE
   """
@@ -15,6 +13,7 @@ type Account implements IAccount {
   账号资料
   """
   AccountProfileField: AccountProfile!
+  RecordFieldResolver: [Record!]!
   accountAvaliable: Boolean!
   accountId: ID!
   accountName: String!
@@ -786,7 +785,9 @@ type Recipe {
 union RecipeUnionResult = Cook | Recipe | SaltFish
 
 type Record implements IRecord {
-  RecordFieldResolver: [Record!]!
+  ExecutorFieldResolver: [Executor!]!
+  SubstanceFieldResolver: [Substance!]!
+  TaskFieldResolver: [Task!]!
   createDate: Timestamp!
   lastUpdateDate: Timestamp!
   recordAccount: Account

--- a/server/typegraphql/schema.graphql
+++ b/server/typegraphql/schema.graphql
@@ -205,7 +205,7 @@ type Executor implements IExecutor {
   获取对象类型的执行者描述
   """
   ExecutorDescField: ExecutorDesc!
-  ExecutorFieldResolver: [Executor!]!
+  ExecutorInnerTaskFieldResolver: [Task!]!
   age: Float!
   avaliable: Boolean!
   desc: String!
@@ -785,9 +785,9 @@ type Recipe {
 union RecipeUnionResult = Cook | Recipe | SaltFish
 
 type Record implements IRecord {
-  ExecutorFieldResolver: [Executor!]!
-  SubstanceFieldResolver: [Substance!]!
-  TaskFieldResolver: [Task!]!
+  RecordInnerExecutorFieldResolver: [Executor!]!
+  RecordInnerSubstanceFieldResolver: [Substance!]!
+  RecordInnerTaskFieldResolver: [Task!]!
   createDate: Timestamp!
   lastUpdateDate: Timestamp!
   recordAccount: Account
@@ -913,7 +913,8 @@ input SubstanceUpdateInput {
 }
 
 type Task implements ITask {
-  TaskFieldResolver: [Task!]!
+  TaskInnerExecutorFieldResolver: Executor!
+  TaskInnerSubstanceFieldResolver: Substance!
   allowAbort: Boolean!
   assignee: Executor
   lastUpdateDate: Timestamp!

--- a/server/typegraphql/schema.graphql
+++ b/server/typegraphql/schema.graphql
@@ -4,6 +4,8 @@
 # -----------------------------------------------
 
 type Account implements IAccount {
+  AccountFieldResolver: [Account!]!
+
   """
   ACCOUNT_JSON_TYPE
   """
@@ -153,7 +155,7 @@ type Company {
   description: String!
   name: String!
   registerDate: Timestamp!
-  scale: CompanyScale
+  scale: CompanyScale!
 }
 
 """
@@ -204,6 +206,7 @@ type Executor implements IExecutor {
   获取对象类型的执行者描述
   """
   ExecutorDescField: ExecutorDesc!
+  ExecutorFieldResolver: [Executor!]!
   age: Float!
   avaliable: Boolean!
   desc: String!
@@ -563,8 +566,8 @@ type Notification {
 Pagination Options Input
 """
 input PaginationOptions {
-  cursor: Int
   offset: Int
+  take: Int
 }
 
 type Query {
@@ -783,6 +786,7 @@ type Recipe {
 union RecipeUnionResult = Cook | Recipe | SaltFish
 
 type Record implements IRecord {
+  RecordFieldResolver: [Record!]!
   createDate: Timestamp!
   lastUpdateDate: Timestamp!
   recordAccount: Account
@@ -908,6 +912,7 @@ input SubstanceUpdateInput {
 }
 
 type Task implements ITask {
+  TaskFieldResolver: [Task!]!
   allowAbort: Boolean!
   assignee: Executor
   lastUpdateDate: Timestamp!

--- a/server/typing.ts
+++ b/server/typing.ts
@@ -2,6 +2,7 @@ import { ContainerInstance } from "typedi";
 import DataLoader from "dataloader";
 import { ACCOUNT_TYPE, ACCOUNT_ROLE } from "./utils/constants";
 import { PrismaClient } from "./prisma/client";
+import { Connection } from "typeorm";
 
 export interface IContext {
   currentUser: {
@@ -15,4 +16,5 @@ export interface IContext {
     initialized: boolean;
     loaders: Record<string, Record<string, DataLoader<any, any>>>;
   };
+  connection: Connection;
 }

--- a/server/typing.ts
+++ b/server/typing.ts
@@ -2,8 +2,12 @@ import { ContainerInstance } from "typedi";
 import DataLoader from "dataloader";
 import { ACCOUNT_TYPE, ACCOUNT_ROLE } from "./utils/constants";
 import { PrismaClient } from "./prisma/client";
-import { Connection } from "typeorm";
+import type { Connection } from "typeorm";
 
+export interface TypeGraphQLDataLoaderContext {
+  requestId: string;
+  connectionGetter?: () => Connection;
+}
 export interface IContext {
   currentUser: {
     accountId: number;
@@ -17,4 +21,5 @@ export interface IContext {
     loaders: Record<string, Record<string, DataLoader<any, any>>>;
   };
   connection: Connection;
+  tgdLoader: TypeGraphQLDataLoaderContext;
 }

--- a/server/utils/constants.ts
+++ b/server/utils/constants.ts
@@ -73,8 +73,8 @@ export const PLAY_GROUND_SETTINGS = {
 export const SALT = 10;
 
 export const DEFAULT_QUERY_PAGINATION = {
-  cursor: 0,
-  offset: 20,
+  offset: 0,
+  take: 20,
 } as const;
 
 export const TypeORMCacheIds = {

--- a/server/utils/helper.ts
+++ b/server/utils/helper.ts
@@ -60,15 +60,15 @@ export const mergeJSONWithObj = (json: string, convertion: object): string =>
   });
 
 export interface IPaginationOptions {
-  readonly cursor?: number;
   readonly offset?: number;
+  readonly take?: number;
 }
 
 export const generatePagination = (
   pagination?: IPaginationOptions
 ): Required<IPaginationOptions> => {
   return {
-    cursor: pagination?.cursor ?? DEFAULT_QUERY_PAGINATION.cursor,
     offset: pagination?.offset ?? DEFAULT_QUERY_PAGINATION.offset,
+    take: pagination?.take ?? DEFAULT_QUERY_PAGINATION.take,
   };
 };

--- a/server/utils/mock.ts
+++ b/server/utils/mock.ts
@@ -281,23 +281,67 @@ export const insertInitMockData = async (): Promise<any> => {
     sub4.substanceLevel = DifficultyLevel.OLD_DOMINATOR;
     mockTaskGroup[3].taskSubstance = sub4;
 
+    const sub5 = new Substance();
+    sub5.substanceName = "尼禄";
+    sub5.substanceDesc = "黄金桂冠";
+    sub5.substanceLevel = DifficultyLevel.OLD_DOMINATOR;
+    mockTaskGroup[4].taskSubstance = sub5;
+
     const account1 = new Account();
     account1.accountName = "mock-account-name-01";
     account1.accountPwd = "mock-account-pwd-01";
 
+    const account2 = new Account();
+    account2.accountName = "mock-account-name-02";
+    account2.accountPwd = "mock-account-pwd-02";
+
+    const account3 = new Account();
+    account3.accountName = "mock-account-name-03";
+    account3.accountPwd = "mock-account-pwd-03";
+
     await account1.save();
+    await account2.save();
+    await account3.save();
 
     const record1 = new Record();
     record1.recordAccount = account1;
-    record1.recordExecutor = executor3;
-    record1.recordSubstance = sub4;
-    record1.recordTask = mockTaskGroup[3];
+    record1.recordExecutor = executor1;
+    record1.recordSubstance = sub1;
+    record1.recordTask = mockTaskGroup[0];
+
+    const record2 = new Record();
+    record2.recordAccount = account2;
+    record2.recordExecutor = executor2;
+    record2.recordSubstance = sub2;
+    record2.recordTask = mockTaskGroup[1];
+
+    const record3 = new Record();
+    record3.recordAccount = account3;
+    record3.recordExecutor = executor3;
+    record3.recordSubstance = sub3;
+    record3.recordTask = mockTaskGroup[2];
+
+    const record4 = new Record();
+    record4.recordAccount = account1;
+    record4.recordExecutor = executor3;
+    record4.recordSubstance = sub3;
+    record4.recordTask = mockTaskGroup[3];
+
+    const record5 = new Record();
+    record5.recordAccount = account1;
+    record5.recordExecutor = executor3;
+    record5.recordSubstance = sub4;
+    record5.recordTask = mockTaskGroup[4];
 
     await connection.manager.save(mockTaskGroup);
     await connection.manager.save(mockSubstanceGroup);
     await connection.manager.save(mockExecutorGroup);
 
     await record1.save();
+    await record2.save();
+    await record3.save();
+    await record4.save();
+    await record5.save();
 
     log("[TypeORM] Initial Mock Data Inserted\n");
   } catch (error) {


### PR DESCRIPTION
- 为所有的对象类型支持FieldResolver
- 在每一层的FieldResolver查询中, 支持 **级联** **防止循环查询** **复杂度处理** (基于`@Root()` 注入的父级对象类型)
- 在支持完毕后, 引入DataLoader来处理N+1问题, 包括中间件中的拦截与TypeGraphQL-DataLoader的思路

## Progress

如果要支持以任一对象类型为根节点向下展开, 那么就需要为每一种可能的排列组合创建专用的FieldResolver, 我得好好想想这是否是必要的.

对于N+1的解决方案:
1. 在context中注入为每个对象类型对应service创建的batch query. 这种方式仅适用于1-1的级联关系, 对于多对一和多对多关系, 可能会造成DataLoader BatchLoader的入参与返回值数组长度不一致(比如多个ID对应到同一组数据)
2. 在context中基于`connection.entityMetadatas`注入bacth query, 适用于所有级联关系(待验证), 思路是使用`connection.relationIdLoader.loadManyToManyRelationIdsAndGroup`作为BatchLoadFn.
3. 基于TypeGraphQL-DataLoader, 目前在此项目中fork了一份, 大致思路是在应用启动时会收集到所有级联关系, 并使用对应的handler, 基于useMiddleware来拦截查询.
